### PR TITLE
feat(typeahead): handles min-length of 0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "ignore": [],
     "description": "Native AngularJS (Angular) directives for Bootstrap.",
-    "version": "0.12.1-7",
+    "version": "0.12.1-8",
     "main": ["./ui-bootstrap-tpls.js"],
     "dependencies": {
         "angular": ">=1 <1.3.0"

--- a/ui-bootstrap-tpls.js
+++ b/ui-bootstrap-tpls.js
@@ -3555,9 +3555,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //SUPPORTED ATTRIBUTES (OPTIONS)
 
       //minimal no of characters that needs to be entered before typeahead kicks-in
-      var minSearch = originalScope.$eval(attrs.typeaheadMinLength);
-      if (!minSearch && minSearch !== 0) {
-        minSearch = 1;
+      var minLength = originalScope.$eval(attrs.typeaheadMinLength);
+      if (!minLength && minLength !== 0) {
+        minLength = 1;
       }
 
       //minimal wait time after last character typed before typehead kicks-in
@@ -3710,7 +3710,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         hasFocus = true;
 
-        if (inputValue && inputValue.length >= minSearch) {
+        if (minLength === 0 || inputValue && inputValue.length >= minLength) {
           if (waitTime > 0) {
             cancelPreviousTimeout();
             scheduleSearchWithTimeout(inputValue);
@@ -3825,7 +3825,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       element.bind('focus', function (evt) {
         hasFocus = true;
-        if (minSearch === 0 && !modelCtrl.$viewValue) {
+        if (minLength === 0 && !modelCtrl.$viewValue) {
           $timeout(function() {
             getMatchesAsync(modelCtrl.$viewValue, evt);
           }, 0);

--- a/ui-bootstrap.js
+++ b/ui-bootstrap.js
@@ -3554,9 +3554,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //SUPPORTED ATTRIBUTES (OPTIONS)
 
       //minimal no of characters that needs to be entered before typeahead kicks-in
-      var minSearch = originalScope.$eval(attrs.typeaheadMinLength);
-      if (!minSearch && minSearch !== 0) {
-        minSearch = 1;
+      var minLength = originalScope.$eval(attrs.typeaheadMinLength);
+      if (!minLength && minLength !== 0) {
+        minLength = 1;
       }
 
       //minimal wait time after last character typed before typehead kicks-in
@@ -3709,7 +3709,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         hasFocus = true;
 
-        if (inputValue && inputValue.length >= minSearch) {
+        if (minLength === 0 || inputValue && inputValue.length >= minLength) {
           if (waitTime > 0) {
             cancelPreviousTimeout();
             scheduleSearchWithTimeout(inputValue);
@@ -3824,7 +3824,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       element.bind('focus', function (evt) {
         hasFocus = true;
-        if (minSearch === 0 && !modelCtrl.$viewValue) {
+        if (minLength === 0 && !modelCtrl.$viewValue) {
           $timeout(function() {
             getMatchesAsync(modelCtrl.$viewValue, evt);
           }, 0);


### PR DESCRIPTION
Currently, when min-length is 0, all matches only show on initial focus. But when something is typed and then all input is deleted, the matches disappear. Fix to show all matches in this scenario.  

see [#3600](https://github.com/angular-ui/bootstrap/pull/3600) and [commit](https://github.com/angular-ui/bootstrap/commit/a5a25141fc88e642b84e135796daaf77dc653273)